### PR TITLE
fix: 修复安全报告部分bug，nginx添加响应头配置以及403 error_page

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,4 +35,8 @@ server {
         proxy_read_timeout      30m;
         client_max_body_size    500m;
     }
+    add_header Content-Security-Policy "default-src *;style-src 'self' 'unsafe-inline';script-src 'self' 'unsafe-inline' 'unsafe-eval';img-src * data:;worker-src * blob:;font-src 'self' data:;";
+    add_header X-Content-Type-Options "nosniff";
+    add_header X-XSS-Protection "1";
+    error_page 403 =404 /404.html;
 }


### PR DESCRIPTION
fix: nginx.conf bug
- 添加nginx响应头“Content-Security-Policy”、“X-Content-Type-Options”、“X-XSS-Protection”
- 添加 error_page 配置 (对禁止的资源发布“404 - Not Found”响应状态代码，或者将其完全除去)

