### PR TITLE
feat: 兼容老版本物模型缺失「填写约束」的场景

### DIFF
--- a/src/components/Metadata/Table/components/Object/index.vue
+++ b/src/components/Metadata/Table/components/Object/index.vue
@@ -334,13 +334,20 @@ const addItem = () => {
 };
 
 watch(
-    () => [JSON.stringify(props.value), visible.value],
-    (val) => {
-        if (visible.value) {
-            dataSource.value = JSON.parse(val[0] || '[]');
-        }
-    },
-    { immediate: true },
+		() => [JSON.stringify(props.value), visible.value],
+		(val) => {
+			if (visible.value) {
+				dataSource.value = JSON.parse(val[0] || '[]').map(el => {
+					return {
+						...el,
+						expands: el.expands || {
+							required: false,
+						}
+					}
+				});
+			}
+		},
+		{ immediate: true },
 );
 </script>
 


### PR DESCRIPTION
老版本的参数没有 expands 属性，导致无法正常加载编辑框

![image](https://github.com/user-attachments/assets/79b1313b-a868-4b79-86e3-0bd197f85dbe)
